### PR TITLE
changed plasma to tokamaksource

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,16 @@ pip install openmc-plasma-source
 ```
 
 
-## Basic usage
+## Usage
+
+### Tokamak Source
+
+Create a source with a spatial and temperature distribution of a tokamak plasma.
 
 ```python
-from openmc_plasma_source import Plasma
+from openmc_plasma_source import TokamakSource
 
-
-# create a plasma source
-my_plasma = Plasma(
+my_plasma = TokamakSource(
     elongation=1.557,
     ion_density_centre=1.09e20,
     ion_density_peaking_factor=1,
@@ -46,3 +48,29 @@ my_sources = my_plasma.make_openmc_sources()
 ```
 
 For a more complete example check out the example script.
+
+### Ring Source
+
+
+Create a ring source with temperature distribution of a 2000eV plasma.
+
+```python
+my_plasma = FusionRingSource(
+    start_angle = 0.,
+    stop_angle = 6.28318530718,  # input is in radians
+    temperature = 20000.,
+    fuel='DT'
+)
+```
+### Point Source
+
+Create a point source with temperature distribution of a 2000eV plasma.
+
+
+```python
+my_plasma = FusionPointSource(
+    coordinate = (0, 0, 0),
+    temperature = 20000.,
+    fuel = 'DT'
+)
+```

--- a/examples/tokamak_source_example.py
+++ b/examples/tokamak_source_example.py
@@ -1,9 +1,9 @@
 import openmc
-from openmc_plasma_source import Plasma
+from openmc_plasma_source import TokamakSource
 
 
 # create a plasma source
-my_plasma = Plasma(
+my_plasma = TokamakSource(
     elongation=1.557,
     ion_density_centre=1.09e20,
     ion_density_peaking_factor=1,

--- a/openmc_plasma_source/__init__.py
+++ b/openmc_plasma_source/__init__.py
@@ -1,3 +1,3 @@
-from .main import Plasma
+from .tokamak_source import TokamakSource
 from .ring_source import FusionRingSource
 from .point_source import FusionPointSource

--- a/openmc_plasma_source/tokamak_source.py
+++ b/openmc_plasma_source/tokamak_source.py
@@ -4,7 +4,7 @@ from matplotlib import cm
 from numpy.lib.function_base import iterable
 
 
-class Plasma():
+class TokamakSource():
     """Plasma neutron source sampling.
     This class greatly relies on models described in [1]
 
@@ -27,20 +27,20 @@ class Plasma():
         mode (str): Confinement mode ("L", "H", "A")
         ion_density_centre (float): Ion density at the plasma centre (m-3)
         ion_density_peaking_factor (float): Ion density peaking factor
-            (refered in [1] as ion density exponent)
+            (referred in [1] as ion density exponent)
         ion_density_pedestal (float): Ion density at pedestal (m-3)
         ion_density_separatrix (float): Ion density at separatrix (m-3)
         ion_temperature_centre (float): Ion temperature at the plasma
             centre (keV)
         ion_temperature_peaking_factor (float): Ion temperature peaking
-            factor (refered in [1] as ion temperature exponent alpha_T)
+            factor (referred in [1] as ion temperature exponent alpha_T)
         ion_temperature_beta (float): Ion temperature beta exponent
-            (refered in [1] as ion temperature exponent beta_T)
+            (referred in [1] as ion temperature exponent beta_T)
         ion_temperature_pedestal (float): Ion temperature at pedestal (keV)
         ion_temperature_separatrix (float): Ion temperature at separatrix
             (keV)
         pedestal_radius (float): Minor radius at pedestal (m)
-        shafranov_factor (float): Shafranov factor (refered in [1] as esh)
+        shafranov_factor (float): Shafranov factor (referred in [1] as esh)
             also known as outward radial displacement of magnetic surfaces
             (m)
         sample_size (int, optional): number of neutron sources. Defaults

--- a/tests/test_tokamak_source.py
+++ b/tests/test_tokamak_source.py
@@ -1,9 +1,9 @@
-from openmc_plasma_source import Plasma
+from openmc_plasma_source import TokamkaSource
 
 from openmc import Source
 
 
 def test_creation():
-    my_source = Plasma()
+    my_source = TokamkaSource()
     for source in my_source:
         assert isinstance(source, Source)


### PR DESCRIPTION
This PR :

- changes the ```Plasma``` class name to ```TokamakPlasma``` 
- adds an example ```FusionPointSource``` to the readme
- adds an ```FusionRingSource``` to the readme