### PR TITLE
allowing mplt above 3.2.2 to be installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,6 @@ setuptools.setup(
     python_requires='>=3.6',
     install_requires=[
         'numpy>=1.9',
-        'matplotlib >= 3.4.3'
+        'matplotlib >= 3.2.2'
     ],
 )


### PR DESCRIPTION
this relaxes the requirement of matplotlib a little bit as requested in #30 