### PR TITLE
Revert matplotlib version to 3.2.2

### DIFF
--- a/openmc_plasma_source/tokamak_source.py
+++ b/openmc_plasma_source/tokamak_source.py
@@ -270,7 +270,7 @@ def neutron_source_density(ion_density, ion_temperature):
     Returns:
         float, ndarray: Neutron source density (neutron/s/m3)
     """
-    return ion_density ** 2 * DT_xs(ion_temperature)
+    return ion_density**2 * DT_xs(ion_temperature)
 
 
 def DT_xs(ion_temperature):

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ packages = find:
 python_requires= >=3.6
 install_requires=
     numpy >= 1.9
-    matplotlib >= 3.4.3
+    matplotlib >= 3.2.2
     importlib-metadata; python_version < "3.8"
 
 [options.extras_require]


### PR DESCRIPTION
Requirements were set higher than necessary, reverting to previous requirements.