### PR TITLE
Improved point and ring sources

### DIFF
--- a/openmc_plasma_source/fuel_types.py
+++ b/openmc_plasma_source/fuel_types.py
@@ -4,13 +4,16 @@ Defines dictionary for determining mean energy and mass of reactants
 for a given fusion fuel type.
 """
 
-from dataclasses import dataclass
+import proper_tea as pt
 
 
-@dataclass
 class Fuel:
-    mean_energy: float  # mean energy, eV
-    mass_of_reactants: float  # mass of the reactants, AMU
+    mean_energy = pt.positive_float(allow_zero=False)  # mean energy, eV
+    mass_of_reactants = pt.positive(allow_zero=False)  # mass of the reactants, AMU
+
+    def __init__(self, mean_energy, mass_of_reactants):
+        self.mean_energy = mean_energy
+        self.mass_of_reactants = mass_of_reactants
 
 
 fuel_types = {

--- a/openmc_plasma_source/fuel_types.py
+++ b/openmc_plasma_source/fuel_types.py
@@ -1,0 +1,19 @@
+"""fuel_types.py
+
+Defines dictionary for determining mean energy and mass of reactants
+for a given fusion fuel type.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Fuel:
+    mean_energy: float  # mean energy, eV
+    mass_of_reactants: float  # mass of the reactants, AMU
+
+
+fuel_types = {
+    "DD": Fuel(mean_energy=2450000.0, mass_of_reactants=4),
+    "DT": Fuel(mean_energy=14080000.0, mass_of_reactants=5),
+}

--- a/openmc_plasma_source/point_source.py
+++ b/openmc_plasma_source/point_source.py
@@ -1,4 +1,7 @@
 from typing import Tuple
+import proper_tea as pt
+import proper_tea.numpy
+from .fuel_types import fuel_types
 
 import openmc
 
@@ -8,28 +11,38 @@ class FusionPointSource(openmc.Source):
     for fusion simulations using a point source. All attributes can be changed
     after initialization if required. Default isotropic point source at the
     origin with a Muir energy distribution.
+
+    Args:
+        coordinate (tuple[float,float,float]): Location of the point source.
+            Each component is measured in metres.
+        temperature (float): Temperature of the source (eV).
+        fuel_type (str): The fusion fuel mix. Either 'DT' or 'DD'.
     """
+
+    coordinate = pt.numpy.numpy_array(shape=(3,), dtype=float)
+    temperature = pt.positive_float()  # temperature in eV
+    fuel_type = pt.in_set(fuel_types.keys())
 
     def __init__(
         self,
         coordinate: Tuple[float, float, float] = (0, 0, 0),
         temperature: float = 20000.0,
-        fuel: str = "DT",
+        fuel_type: str = "DT",
     ):
+        # Set local attributes
+        self.coordinate = coordinate
+        self.temperature = temperature
+        self.fuel_type = fuel_type
+        self.fuel = fuel_types[self.fuel_type]
 
+        # Call init for openmc.Source
         super().__init__()
 
         # performed after the super init as these are Source attributes
-        self.space = openmc.stats.Point(coordinate)
+        self.space = openmc.stats.Point(self.coordinate)
         self.angle = openmc.stats.Isotropic()
-        if fuel == "DT":
-            mean_energy = 14080000.0  # mean energy in eV
-            mass_of_reactants = 5  # mass of the reactants (D + T) AMU
-        elif fuel == "DD":
-            mean_energy = 2450000.0  # mean energy in eV
-            mass_of_reactants = 4  # mass of the reactants (D + D) AMU
-        else:
-            raise ValueError(f'fuel must be either "DT" or "DD", not {fuel}')
         self.energy = openmc.stats.Muir(
-            e0=mean_energy, m_rat=mass_of_reactants, kt=temperature
+            e0=self.fuel.mean_energy,
+            m_rat=self.fuel.mass_of_reactants,
+            kt=self.temperature,
         )

--- a/openmc_plasma_source/ring_source.py
+++ b/openmc_plasma_source/ring_source.py
@@ -1,5 +1,10 @@
-import openmc
+from typing import Tuple
 import numpy as np
+import proper_tea as pt
+import proper_tea.numpy
+from .fuel_types import fuel_types
+
+import openmc
 
 
 class FusionRingSource(openmc.Source):
@@ -9,39 +14,49 @@ class FusionRingSource(openmc.Source):
     energy distribution.
 
     Args:
-        radius: the inner radius of the ring source
-        angles (iterable of floats): the start and stop angles of the ring in radians,
-        z_placement: Location of the ring source (m). Defaults to 0.
-        temperature: the temperature to use in the Muir distribution in eV,
+        radius (float): the inner radius of the ring source, in metres
+        angles (iterable of floats): the start and stop angles of the ring in radians
+        z_placement (float): Location of the ring source (m). Defaults to 0.
+        temperature (float): the temperature to use in the Muir distribution in eV,
+        fuel_type (str): The fusion fuel mix. Either 'DT' or 'DD'.
     """
+
+    radius = pt.positive_float()
+    angles = pt.numpy.numpy_array(shape=(2,), dtype=float, sort=True)
+    z_placement = pt.floating_point()
+    temperature = pt.positive_float()
+    fuel_type = pt.in_set(fuel_types.keys())
 
     def __init__(
         self,
-        radius,
-        angles=(0, 2 * np.pi),
-        z_placement=0,
+        radius: float,
+        angles: Tuple[float, float] = (0, 2 * np.pi),
+        z_placement: float = 0,
         temperature: float = 20000.0,
-        fuel="DT",
+        fuel_type: str = "DT",
     ):
 
+        # Set local attributes
+        self.radius = radius
+        self.angles = angles
+        self.z_placement = z_placement
+        self.temperature = temperature
+        self.fuel_type = fuel_type
+        self.fuel = fuel_types[self.fuel_type]
+
+        # Call init for openmc.Source
         super().__init__()
 
         # performed after the super init as these are Source attributes
-        radius = openmc.stats.Discrete([radius], [1])
-        z_values = openmc.stats.Discrete([z_placement], [1])
-        angle = openmc.stats.Uniform(a=angles[0], b=angles[1])
         self.space = openmc.stats.CylindricalIndependent(
-            r=radius, phi=angle, z=z_values, origin=(0.0, 0.0, 0.0)
+            r=openmc.stats.Discrete([self.radius], [1]),
+            phi=openmc.stats.Uniform(a=self.angles[0], b=self.angles[1]),
+            z=openmc.stats.Discrete([self.z_placement], [1]),
+            origin=(0.0, 0.0, 0.0),
         )
         self.angle = openmc.stats.Isotropic()
-        if fuel == "DT":
-            mean_energy = 14080000.0  # mean energy in eV
-            mass_of_reactants = 5  # mass of the reactants (D + T) AMU
-        elif fuel == "DD":
-            mean_energy = 2450000.0  # mean energy in eV
-            mass_of_reactants = 4  # mass of the reactants (D + D) AMU
-        else:
-            raise ValueError(f'fuel must be either "DT" or "DD", not {fuel}')
         self.energy = openmc.stats.Muir(
-            e0=mean_energy, m_rat=mass_of_reactants, kt=temperature
+            e0=self.fuel.mean_energy,
+            m_rat=self.fuel.mass_of_reactants,
+            kt=self.temperature,
         )

--- a/openmc_plasma_source/tokamak_source.py
+++ b/openmc_plasma_source/tokamak_source.py
@@ -319,7 +319,7 @@ def neutron_source_density(ion_density, ion_temperature):
     ion_density = np.asarray(ion_density)
     ion_temperature = np.asarray(ion_temperature)
 
-    return ion_density ** 2 * DT_xs(ion_temperature)
+    return ion_density**2 * DT_xs(ion_temperature)
 
 
 def DT_xs(ion_temperature):

--- a/openmc_plasma_source/tokamak_source.py
+++ b/openmc_plasma_source/tokamak_source.py
@@ -319,7 +319,7 @@ def neutron_source_density(ion_density, ion_temperature):
     ion_density = np.asarray(ion_density)
     ion_temperature = np.asarray(ion_temperature)
 
-    return ion_density**2 * DT_xs(ion_temperature)
+    return ion_density ** 2 * DT_xs(ion_temperature)
 
 
 def DT_xs(ion_temperature):

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ python_requires= >=3.6
 install_requires=
     numpy >= 1.9
     matplotlib >= 3.2.2
-    proper_tea ~= 0.2.0
+    proper_tea ~= 0.3.1
     importlib-metadata; python_version < "3.8"
 
 [options.extras_require]

--- a/tests/test_fuel_types.py
+++ b/tests/test_fuel_types.py
@@ -1,0 +1,32 @@
+from openmc_plasma_source.fuel_types import Fuel, fuel_types
+import pytest
+
+
+@pytest.mark.parametrize("energy,mass", [(2.5e7, 5), (15, 30)])
+def test_fuel_with_correct_inputs(energy, mass):
+    # Should accept any non-zero positive inputs to either variable
+    fuel = Fuel(energy, mass)
+    assert fuel.mean_energy == energy
+    assert fuel.mass_of_reactants == mass
+
+
+@pytest.mark.parametrize(
+    "energy,mass", [(2.5e7, -5), (-12, 30), (1e7, 0), (0, 4), (-12, -12)]
+)
+def test_fuel_with_bad_inputs(energy, mass):
+    # Should reject any negative numbers and zeros.
+    with pytest.raises(ValueError):
+        fuel = Fuel(energy, mass)
+
+
+@pytest.mark.parametrize("fuel_type", ["DT", "DD"])
+def test_fuel_types(fuel_type):
+    # Should accept 'DD' and 'DT'
+    assert isinstance(fuel_types[fuel_type], Fuel)
+
+
+@pytest.mark.parametrize("fuel_type", ["dt", "dd", "Dt", "dD", "hello world", 5])
+def test_incorrect_fuel_types(fuel_type):
+    # Should reject everything except 'DT' and 'DD'
+    with pytest.raises(KeyError):
+        my_fuel = fuel_types[fuel_type]

--- a/tests/test_point_source.py
+++ b/tests/test_point_source.py
@@ -1,14 +1,67 @@
 from openmc_plasma_source import FusionPointSource
 
-from openmc import Source
+import openmc
 import pytest
+import numpy as np
 
 
 def test_creation():
     my_source = FusionPointSource()
-    assert isinstance(my_source, Source)
+
+    # Ensure it is of type openmc.Source
+    assert isinstance(my_source, openmc.Source)
+
+    # Ensure it has space, angle, and energy set
+    assert isinstance(my_source.space, openmc.stats.Point)
+    assert isinstance(my_source.angle, openmc.stats.Isotropic)
+    assert isinstance(my_source.energy, openmc.stats.Muir)
+
+
+def test_coordinate():
+    # Should allow any iterable of length 3 with contents convertible to float
+    success_states = [(1.0, 2.0, 3.0), [4, 5, 6], np.linspace(1.0, 3.0, 3)]
+    for success_state in success_states:
+        my_source = FusionPointSource(coordinate=success_state)
+        assert np.all(np.equal(my_source.coordinate, success_state))
+
+
+def test_bad_coordinate():
+    # Should reject iterables of length != 3, anything non iterable, and anything
+    # that can't convert to float
+    fail_states = [(1, 2), [1, 2, 3, 4], 5, "abc"]
+    for fail_state in fail_states:
+        with pytest.raises(ValueError):
+            FusionPointSource(coordinate=fail_state)
+
+
+def test_temperature():
+    # Should accept any positive float
+    success_states = [20000.0, 1e4, 0.1, 25000]
+    for success_state in success_states:
+        my_source = FusionPointSource(temperature=success_state)
+        assert my_source.temperature == success_state
+
+
+def test_bad_temperature():
+    # Should reject negative floats and anything that isn't convertible to float
+    fail_states = [-20000.0, "hello world", [10000]]
+    for fail_state in fail_states:
+        with pytest.raises(ValueError):
+            FusionPointSource(temperature=fail_state)
+
+
+def test_fuel():
+    # Should accept either 'DD' or 'DT'
+    my_source = FusionPointSource(fuel_type="DT")
+    assert my_source.fuel_type == "DT"
+    my_source = FusionPointSource(fuel_type="DD")
+    assert my_source.fuel_type == "DD"
 
 
 def test_wrong_fuel():
+    # Should reject fuel types besides those listed in fuel_types.py
     with pytest.raises(ValueError):
-        FusionPointSource(fuel="топливо")
+        FusionPointSource(fuel_type="топливо")
+    # Should also reject non-strings
+    with pytest.raises(ValueError):
+        FusionPointSource(fuel_type=5)

--- a/tests/test_point_source.py
+++ b/tests/test_point_source.py
@@ -17,51 +17,46 @@ def test_creation():
     assert isinstance(my_source.energy, openmc.stats.Muir)
 
 
-def test_coordinate():
+@pytest.mark.parametrize(
+    "coordinate", [(1.0, 2.0, 3.0), [4, 5, 6], np.linspace(1.0, 3.0, 3)]
+)
+def test_coordinate(coordinate):
     # Should allow any iterable of length 3 with contents convertible to float
-    success_states = [(1.0, 2.0, 3.0), [4, 5, 6], np.linspace(1.0, 3.0, 3)]
-    for success_state in success_states:
-        my_source = FusionPointSource(coordinate=success_state)
-        assert np.all(np.equal(my_source.coordinate, success_state))
+    my_source = FusionPointSource(coordinate=coordinate)
+    assert np.array_equal(my_source.coordinate, coordinate)
 
 
-def test_bad_coordinate():
+@pytest.mark.parametrize("coordinate", [(1, 2), [3, 4, 5, 6], 5, "abc"])
+def test_bad_coordinate(coordinate):
     # Should reject iterables of length != 3, anything non iterable, and anything
     # that can't convert to float
-    fail_states = [(1, 2), [1, 2, 3, 4], 5, "abc"]
-    for fail_state in fail_states:
-        with pytest.raises(ValueError):
-            FusionPointSource(coordinate=fail_state)
+    with pytest.raises(ValueError):
+        FusionPointSource(coordinate=coordinate)
 
 
-def test_temperature():
+@pytest.mark.parametrize("temperature", [20000.0, 1e4, 0.1, 25000])
+def test_temperature(temperature):
     # Should accept any positive float
-    success_states = [20000.0, 1e4, 0.1, 25000]
-    for success_state in success_states:
-        my_source = FusionPointSource(temperature=success_state)
-        assert my_source.temperature == success_state
+    my_source = FusionPointSource(temperature=temperature)
+    assert my_source.temperature == temperature
 
 
-def test_bad_temperature():
+@pytest.mark.parametrize("temperature", [-20000.0, "hello world", [10000]])
+def test_bad_temperature(temperature):
     # Should reject negative floats and anything that isn't convertible to float
-    fail_states = [-20000.0, "hello world", [10000]]
-    for fail_state in fail_states:
-        with pytest.raises(ValueError):
-            FusionPointSource(temperature=fail_state)
+    with pytest.raises(ValueError):
+        FusionPointSource(temperature=temperature)
 
 
-def test_fuel():
+@pytest.mark.parametrize("fuel_type", ["DT", "DD"])
+def test_fuel(fuel_type):
     # Should accept either 'DD' or 'DT'
-    my_source = FusionPointSource(fuel_type="DT")
-    assert my_source.fuel_type == "DT"
-    my_source = FusionPointSource(fuel_type="DD")
-    assert my_source.fuel_type == "DD"
+    my_source = FusionPointSource(fuel_type=fuel_type)
+    assert my_source.fuel_type == fuel_type
 
 
-def test_wrong_fuel():
+@pytest.mark.parametrize("fuel_type", ["топливо", 5])
+def test_wrong_fuel(fuel_type):
     # Should reject fuel types besides those listed in fuel_types.py
     with pytest.raises(ValueError):
-        FusionPointSource(fuel_type="топливо")
-    # Should also reject non-strings
-    with pytest.raises(ValueError):
-        FusionPointSource(fuel_type=5)
+        FusionPointSource(fuel_type=fuel_type)

--- a/tests/test_ring_source.py
+++ b/tests/test_ring_source.py
@@ -17,69 +17,60 @@ def test_creation():
     assert isinstance(my_source.energy, openmc.stats.Muir)
 
 
-def test_radius():
+@pytest.mark.parametrize("radius", [1.0, 5.6, 1e5, 7])
+def test_radius(radius):
     # should allow any positive float
-    success_states = [1.0, 5.6, 1e5, 7]
-    for success_state in success_states:
-        my_source = FusionRingSource(radius=success_state)
-        assert my_source.radius == success_state
+    my_source = FusionRingSource(radius=radius)
+    assert my_source.radius == radius
 
 
-def test_bad_radius():
+@pytest.mark.parametrize("radius", [-1.0, "hello world", [1e5]])
+def test_bad_radius(radius):
     # should reject any negative float or anything not convertible to float
-    failure_states = [-1.0, "hello world", [1e5]]
-    for failure_state in failure_states:
-        with pytest.raises(ValueError):
-            my_source = FusionRingSource(radius=failure_state)
+    with pytest.raises(ValueError):
+        my_source = FusionRingSource(radius=radius)
 
 
-def test_angles():
+@pytest.mark.parametrize("angles", [(1.0, 2), [0, np.pi], (np.pi, 0)])
+def test_angles(angles):
     # Should allow any iterable of length 2 with contents convertible to float
     # If angles are given in reverse order, it should sort them automatically
-    success_states = [(1.0, 2), [0, np.pi], (np.pi, 0)]
-    for success_state in success_states:
-        my_source = FusionRingSource(radius=1.0, angles=success_state)
-        assert np.all(np.equal(my_source.angles, sorted(success_state)))
-        assert my_source.angles[0] < my_source.angles[1]
+    my_source = FusionRingSource(radius=1.0, angles=angles)
+    assert np.array_equal(my_source.angles, sorted(angles))
+    assert my_source.angles[0] < my_source.angles[1]
 
 
-def test_bad_angles():
+@pytest.mark.parametrize("angles", [(1,), [1, 2, 3, 4], 5, "ab"])
+def test_bad_angles(angles):
     # Should reject iterables of length != 2, anything non iterable, and anything
     # that can't convert to float
-    fail_states = [(1,), [1, 2, 3, 4], 5, "ab"]
-    for fail_state in fail_states:
-        with pytest.raises(ValueError):
-            FusionRingSource(radius=1.0, angles=fail_state)
+    with pytest.raises(ValueError):
+        FusionRingSource(radius=1.0, angles=angles)
 
 
-def test_temperature():
+@pytest.mark.parametrize("temperature", [20000.0, 1e4, 0.1, 25000])
+def test_temperature(temperature):
     # Should accept any positive float
-    success_states = [20000.0, 1e4, 0.1, 25000]
-    for success_state in success_states:
-        my_source = FusionRingSource(radius=1.0, temperature=success_state)
-        assert my_source.temperature == success_state
+    my_source = FusionRingSource(radius=1.0, temperature=temperature)
+    assert my_source.temperature == temperature
 
 
-def test_bad_temperature():
+@pytest.mark.parametrize("temperature", [-20000.0, "hello world", [10000]])
+def test_bad_temperature(temperature):
     # Should reject negative floats and anything that isn't convertible to float
-    fail_states = [-20000.0, "hello world", [10000]]
-    for fail_state in fail_states:
-        with pytest.raises(ValueError):
-            FusionRingSource(radius=1.0, temperature=fail_state)
+    with pytest.raises(ValueError):
+        FusionRingSource(radius=1.0, temperature=temperature)
 
 
-def test_fuel():
+@pytest.mark.parametrize("fuel_type", ["DT", "DD"])
+def test_fuel(fuel_type):
     # Should accept either 'DD' or 'DT'
-    my_source = FusionRingSource(radius=1.0, fuel_type="DT")
-    assert my_source.fuel_type == "DT"
-    my_source = FusionRingSource(radius=1.0, fuel_type="DD")
-    assert my_source.fuel_type == "DD"
+    my_source = FusionRingSource(radius=1.0, fuel_type=fuel_type)
+    assert my_source.fuel_type == fuel_type
 
 
-def test_wrong_fuel():
+@pytest.mark.parametrize("fuel_type", ["топливо", 5])
+def test_wrong_fuel(fuel_type):
     # Should reject fuel types besides those listed in fuel_types.py
     with pytest.raises(ValueError):
-        FusionRingSource(radius=1.0, fuel_type="топливо")
-    # Should also reject non-strings
-    with pytest.raises(ValueError):
-        FusionRingSource(radius=1.0, fuel_type=5)
+        FusionRingSource(radius=1.0, fuel_type=fuel_type)

--- a/tests/test_ring_source.py
+++ b/tests/test_ring_source.py
@@ -1,14 +1,85 @@
 from openmc_plasma_source import FusionRingSource
 
-from openmc import Source
+import openmc
 import pytest
+import numpy as np
 
 
 def test_creation():
     my_source = FusionRingSource(radius=1, z_placement=1)
-    assert isinstance(my_source, Source)
+
+    # Ensure it is of type openmc.Source
+    assert isinstance(my_source, openmc.Source)
+
+    # Ensure it has space, angle, and energy set
+    assert isinstance(my_source.space, openmc.stats.CylindricalIndependent)
+    assert isinstance(my_source.angle, openmc.stats.Isotropic)
+    assert isinstance(my_source.energy, openmc.stats.Muir)
+
+
+def test_radius():
+    # should allow any positive float
+    success_states = [1.0, 5.6, 1e5, 7]
+    for success_state in success_states:
+        my_source = FusionRingSource(radius=success_state)
+        assert my_source.radius == success_state
+
+
+def test_bad_radius():
+    # should reject any negative float or anything not convertible to float
+    failure_states = [-1.0, "hello world", [1e5]]
+    for failure_state in failure_states:
+        with pytest.raises(ValueError):
+            my_source = FusionRingSource(radius=failure_state)
+
+
+def test_angles():
+    # Should allow any iterable of length 2 with contents convertible to float
+    # If angles are given in reverse order, it should sort them automatically
+    success_states = [(1.0, 2), [0, np.pi], (np.pi, 0)]
+    for success_state in success_states:
+        my_source = FusionRingSource(radius=1.0, angles=success_state)
+        assert np.all(np.equal(my_source.angles, sorted(success_state)))
+        assert my_source.angles[0] < my_source.angles[1]
+
+
+def test_bad_angles():
+    # Should reject iterables of length != 2, anything non iterable, and anything
+    # that can't convert to float
+    fail_states = [(1,), [1, 2, 3, 4], 5, "ab"]
+    for fail_state in fail_states:
+        with pytest.raises(ValueError):
+            FusionRingSource(radius=1.0, angles=fail_state)
+
+
+def test_temperature():
+    # Should accept any positive float
+    success_states = [20000.0, 1e4, 0.1, 25000]
+    for success_state in success_states:
+        my_source = FusionRingSource(radius=1.0, temperature=success_state)
+        assert my_source.temperature == success_state
+
+
+def test_bad_temperature():
+    # Should reject negative floats and anything that isn't convertible to float
+    fail_states = [-20000.0, "hello world", [10000]]
+    for fail_state in fail_states:
+        with pytest.raises(ValueError):
+            FusionRingSource(radius=1.0, temperature=fail_state)
+
+
+def test_fuel():
+    # Should accept either 'DD' or 'DT'
+    my_source = FusionRingSource(radius=1.0, fuel_type="DT")
+    assert my_source.fuel_type == "DT"
+    my_source = FusionRingSource(radius=1.0, fuel_type="DD")
+    assert my_source.fuel_type == "DD"
 
 
 def test_wrong_fuel():
+    # Should reject fuel types besides those listed in fuel_types.py
     with pytest.raises(ValueError):
-        FusionRingSource(radius=1, fuel="топливо")
+        FusionRingSource(radius=1.0, fuel_type="топливо")
+    # Should also reject non-strings
+    with pytest.raises(ValueError):
+        FusionRingSource(radius=1.0, fuel_type=5)


### PR DESCRIPTION
I've updated FusionPointSource and FusionRingSource to store their inputs as properties, which allows them to be checked for validity. Info on DT/DD fuel types has been moved to a new class, which may be refactored later if work on Issue https://github.com/fusion-energy/openmc-plasma-source/issues/37 goes ahead. I've also added unit tests for these new features.