### PR TITLE
Older version of openmc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   # test:
   build:
     docker:
-      - image: openmc/openmc
+      - image: openmc/openmc:v0.12.2
     steps:
       - checkout
       - run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   testing:
     runs-on: ubuntu-latest
     container:
-      image: openmc/openmc
+      image: openmc/openmc:v0.12.2
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Linked to the bug observed in #56.

This PR sets the openmc docker image in the CI workflows to v0.12.2