### PR TITLE
classes are now SourceWithPlotting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,7 @@ dmypy.json
 
 # image files created by tests
 tests/*.png
+
+# openmc output files
+*.h5
+*.out

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ my_source = TokamakSource(
     shafranov_factor=0.44789,
     triangularity=0.270,
     ion_temperature_beta=6
+    sample_size=1000,
+    angles = (0, 2*3.14)  # angle in radians
   ).make_openmc_sources()
 ```
 
@@ -52,7 +54,6 @@ For a more complete example check out the [example script](https://github.com/fu
  ![out](https://user-images.githubusercontent.com/40028739/135098576-a94709ef-96b4-4b8d-8fa0-76a201b6c5d2.png)
 
 ### Ring Source
-
 
 Create a ring source with temperature distribution of a 2000 eV plasma.
 
@@ -80,6 +81,10 @@ my_plasma = FusionPointSource(
     fuel = 'DT'  # or 'DD'
 )
 ```
+
+## Plotting
+
+All sources are ```openmc_source_plotter.SourceWithPlotting()``` objects which inherit from ```openmc.Source()``` and can therefore be used as ```openmc.Source()```. The objects are also extended to provide convenient plotting methods. See [openmc_source_plotter](https://github.com/fusion-energy/openmc_source_plotter) for more details.
 
 ## Testing
 

--- a/examples/tokamak_source_example.py
+++ b/examples/tokamak_source_example.py
@@ -44,7 +44,7 @@ settings = openmc.Settings()
 settings.run_mode = "fixed source"
 settings.batches = 10
 settings.particles = 1000
-settings.source = my_plasma.sources
+settings.source = my_plasma.sources  # the .sources attribute returns a list of openmc.Sources
 
 # Finally, define a mesh tally so that we can see the resulting flux
 mesh = openmc.RegularMesh()

--- a/examples/tokamak_source_example.py
+++ b/examples/tokamak_source_example.py
@@ -44,7 +44,9 @@ settings = openmc.Settings()
 settings.run_mode = "fixed source"
 settings.batches = 10
 settings.particles = 1000
-settings.source = my_plasma.sources  # the .sources attribute returns a list of openmc.Sources
+settings.source = (
+    my_plasma.sources
+)  # the .sources attribute returns a list of openmc.Sources
 
 # Finally, define a mesh tally so that we can see the resulting flux
 mesh = openmc.RegularMesh()

--- a/openmc_plasma_source/point_source.py
+++ b/openmc_plasma_source/point_source.py
@@ -1,15 +1,16 @@
 import openmc
+from openmc_source_plotter import SourceWithPlotting
 from typing import Tuple
 from param import Parameterized, Number, NumericTuple, ListSelector
 
 from .fuel_types import fuel_types
 
 
-class FusionPointSource(openmc.Source, Parameterized):
-    """An openmc.Source object with some presets to make it more convenient
-    for fusion simulations using a point source. All attributes can be changed
-    after initialization if required. Default isotropic point source at the
-    origin with a Muir energy distribution.
+class FusionPointSource(SourceWithPlotting, Parameterized):
+    """An extended openmc.Source object with some presets to make it more
+    convenient for fusion simulations and plotting. All attributes can be
+    changed after initialization if required. Default isotropic point source at
+    the origin with a Muir energy distribution.
 
     Args:
         coordinate (tuple[float,float,float]): Location of the point source.

--- a/openmc_plasma_source/ring_source.py
+++ b/openmc_plasma_source/ring_source.py
@@ -1,4 +1,5 @@
 import openmc
+from openmc_source_plotter import SourceWithPlotting
 import numpy as np
 from typing import Tuple
 from param import Parameterized, Number, Range, ListSelector
@@ -6,11 +7,12 @@ from param import Parameterized, Number, Range, ListSelector
 from .fuel_types import fuel_types
 
 
-class FusionRingSource(openmc.Source, Parameterized):
-    """An openmc.Source object with some presets to make it more convenient
-    for fusion simulations using a ring source. All attributes can be changed
-    after initialization if required. Default isotropic ring source with a Muir
-    energy distribution.
+class FusionRingSource(SourceWithPlotting, Parameterized):
+    """An extended openmc.Source object with some presets to make it more
+    convenient for fusion simulations and plotting. All attributes can be
+    changed after initialization if required. Default isotropic ring source
+    with a Muir energy distribution. For more details on plotting features see
+    https://github.com/fusion-energy/openmc_source_plotter
 
     Args:
         radius (float): the inner radius of the ring source, in metres

--- a/openmc_plasma_source/tokamak_source.py
+++ b/openmc_plasma_source/tokamak_source.py
@@ -1,4 +1,5 @@
 import openmc
+from openmc_source_plotter import SourceWithPlotting
 import numpy as np
 from typing import Tuple
 from param import Parameterized, Number, Integer, Range, ListSelector
@@ -259,7 +260,7 @@ class TokamakSource(Parameterized):
         sources = []
         # create a ring source for each sample in the plasma source
         for i in range(len(self.strengths)):
-            my_source = openmc.Source()
+            my_source = SourceWithPlotting()
 
             # extract the RZ values accordingly
             radius = openmc.stats.Discrete([self.RZ[0][i]], [1])

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires=
     matplotlib >= 3.2.2
     param ~= 1.12.0
     importlib-metadata; python_version < "3.8"
+    openmc_source_plotter >= 0.5.0
 
 [options.extras_require]
 tests = 


### PR DESCRIPTION
This PR adds some plotting features to the package.

The sources are now instances of ```openmc_source_plotter.SourceWithPlotting()``` which is just a class that inherits ```openmc.Source``` and adds some plotting methods.

The additional plotting methods are ```.plot_source_position```, ```.plot_source_energy```, ```.plot_source_direction``` and there is also a sampling method called ```sample_initial_particles```

This doesn't remove any of the existing plotting methods but adds a few new ones.
