### PR TITLE
Fix test randomly failing

### DIFF
--- a/tests/test_tokamak_source.py
+++ b/tests/test_tokamak_source.py
@@ -301,7 +301,7 @@ def tokamak_source_strategy(draw):
         shafranov_factor=shafranov_factor,
         ion_density_centre=1.09e20,
         ion_density_peaking_factor=1,
-        ion_density_pedestal=1.09e20,
+        ion_density_pedestal=1.01e20,
         ion_density_separatrix=3e19,
         ion_temperature_centre=45.9,
         ion_temperature_peaking_factor=8.06,


### PR DESCRIPTION
This PR fixes #64 by making sure `ion_density_centre` and `ion_density_pedestal` are different.

I don't understand why this didn't show up before though!