### PR TITLE
Refactor to functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   testing:
     runs-on: ubuntu-latest
     container:
-      image: openmc/openmc:v0.13.3
+      image: openmc/openmc:develop
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       image: openmc/openmc:v0.13.3
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       
       - name: Install
         run: |

--- a/openmc_plasma_source/fuel_types.py
+++ b/openmc_plasma_source/fuel_types.py
@@ -1,25 +1,13 @@
-"""fuel_types.py
 
-Defines dictionary for determining mean energy and mass of reactants
-for a given fusion fuel type.
-"""
+def get_muir_paramters(reactants: str):
+    
+    if reactants == "DD":
+        mean_energy=2450000.0
+        mass_of_reactants=4
+    elif reactants == 'DT:
+        mean_energy=14080000.0
+        mass_of_reactants=5
+    else:
+        raise ValueError(f'Only DD and DT fuel reactants are supported. Not {reactant}')
 
-from param import Parameterized, Number
-
-
-class Fuel(Parameterized):
-    # mean energy, eV
-    mean_energy = Number(None, bounds=(0, None), inclusive_bounds=(False, False))
-
-    # mass of the reactants, AMU
-    mass_of_reactants = Number(None, bounds=(0, None), inclusive_bounds=(False, False))
-
-    def __init__(self, mean_energy, mass_of_reactants):
-        self.mean_energy = mean_energy
-        self.mass_of_reactants = mass_of_reactants
-
-
-fuel_types = {
-    "DD": Fuel(mean_energy=2450000.0, mass_of_reactants=4),
-    "DT": Fuel(mean_energy=14080000.0, mass_of_reactants=5),
-}
+    return mean_energy, mass_of_reactants

--- a/openmc_plasma_source/point_source.py
+++ b/openmc_plasma_source/point_source.py
@@ -5,7 +5,7 @@ from param import Parameterized, Number, NumericTuple, ListSelector
 from .fuel_types import fuel_types
 
 
-class FusionPointSource(openmc.Source, Parameterized):
+class FusionPointSource(openmc.IndependentSource):
     """An openmc.Source object with some presets to make it more convenient
     for fusion simulations using a point source. All attributes can be changed
     after initialization if required. Default isotropic point source at the

--- a/openmc_plasma_source/point_source.py
+++ b/openmc_plasma_source/point_source.py
@@ -5,7 +5,7 @@ from param import Parameterized, Number, NumericTuple, ListSelector
 from .fuel_types import fuel_types
 
 
-class FusionPointSource(openmc.IndependentSource):
+class FusionPointSource(openmc.IndependentSource, Parameterized):
     """An openmc.Source object with some presets to make it more convenient
     for fusion simulations using a point source. All attributes can be changed
     after initialization if required. Default isotropic point source at the

--- a/openmc_plasma_source/ring_source.py
+++ b/openmc_plasma_source/ring_source.py
@@ -6,7 +6,7 @@ from param import Parameterized, Number, Range, ListSelector
 from .fuel_types import fuel_types
 
 
-class FusionRingSource(openmc.Source, Parameterized):
+class FusionRingSource(openmc.IndependentSource):
     """An openmc.Source object with some presets to make it more convenient
     for fusion simulations using a ring source. All attributes can be changed
     after initialization if required. Default isotropic ring source with a Muir

--- a/openmc_plasma_source/ring_source.py
+++ b/openmc_plasma_source/ring_source.py
@@ -6,7 +6,7 @@ from param import Parameterized, Number, Range, ListSelector
 from .fuel_types import fuel_types
 
 
-class FusionRingSource(openmc.IndependentSource):
+class FusionRingSource(openmc.IndependentSource, Parameterized):
     """An openmc.Source object with some presets to make it more convenient
     for fusion simulations using a ring source. All attributes can be changed
     after initialization if required. Default isotropic ring source with a Muir

--- a/openmc_plasma_source/tokamak_source.py
+++ b/openmc_plasma_source/tokamak_source.py
@@ -255,13 +255,13 @@ class TokamakSource(Parameterized):
             Defaults to (0, 2*np.pi).
 
         Returns:
-            list: list of openmc.Source()
+            list: list of openmc.IndependentSource()
         """
 
         sources = []
         # create a ring source for each sample in the plasma source
         for i in range(len(self.strengths)):
-            my_source = openmc.Source()
+            my_source = openmc.IndependentSource()
 
             # extract the RZ values accordingly
             radius = openmc.stats.Discrete([self.RZ[0][i]], [1])


### PR DESCRIPTION
Given the impending change to openmc https://github.com/fusion-energy/openmc-plasma-source/issues/80 I wanted to try another solution that didn't involve inheriting the Source class (as this no longer works)

This PR attempts to refactor the package into functions

work in progess