### PR TITLE
Split jobs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Run tests
         shell: bash -l {0}
         run: |
-          pip install .[tests]
           pytest -v tests
 
       - name: Run examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,24 +10,36 @@ jobs:
   testing:
     runs-on: ubuntu-latest
     steps:
-
       - name: checkout actions
         uses: actions/checkout@v4
 
-      - name: install dependencies
-        shell: bash
-        run: |
+      - name: Set up Conda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: ci-env
+          miniforge-version: latest
+          channels: conda-forge
 
-          wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
-          bash Miniforge3.sh -b -p "${HOME}/conda"
-          source "${HOME}/conda/etc/profile.d/conda.sh"
-          source "${HOME}/conda/etc/profile.d/mamba.sh"
-          mamba activate
-          mamba install -y -c conda-forge openmc
-          pip install .
+      - name: install dependencies
+        shell: bash -l {0}
+        run: |
+          conda install -y -c conda-forge openmc
+          pip install .[tests]
+
+      - name: Test import
+        shell: bash -l {0}
+        run: |
           python -c "import openmc_plasma_source"
+
+      - name: Run tests
+        shell: bash -l {0}
+        run: |
           pip install .[tests]
           pytest -v tests
+
+      - name: Run examples
+        shell: bash -l {0}
+        run: |
           python examples/point_source_example.py
           python examples/ring_source_example.py
           python examples/tokamak_source_example.py


### PR DESCRIPTION
This PR uses the actions `setup-conda` instead of installing conda from scratch.

It also splits jobs in the CI