### PR TITLE
Change major_radius into minor_radius to correct physics

### DIFF
--- a/examples/plot_tokamak_ion_temperature.py
+++ b/examples/plot_tokamak_ion_temperature.py
@@ -20,7 +20,7 @@ temperatures = tokamak_ion_temperature(
     ion_temperature_beta=2,
     ion_temperature_peaking_factor=8.06,
     ion_temperature_separatrix=0.1,
-    major_radius=major_radius,
+    minor_radius=minor_radius,
 )
 
 RZ = tokamak_convert_a_alpha_to_R_Z(

--- a/examples/plot_tokamak_neutron_source_density.py
+++ b/examples/plot_tokamak_neutron_source_density.py
@@ -27,7 +27,7 @@ temperatures = tokamak_ion_temperature(
     ion_temperature_beta=2,
     ion_temperature_peaking_factor=8.06,
     ion_temperature_separatrix=0.1,
-    major_radius=major_radius,
+    minor_radius=minor_radius,
 )
 
 densities = tokamak_ion_density(
@@ -35,7 +35,7 @@ densities = tokamak_ion_density(
     ion_density_centre=ion_density_centre,
     ion_density_peaking_factor=1,
     ion_density_pedestal=1.09e20,
-    major_radius=major_radius,
+    minor_radius=minor_radius,
     pedestal_radius=0.8 * minor_radius,
     ion_density_separatrix=3e19,
     r=a,

--- a/examples/plot_tokamak_neutron_source_strengths.py
+++ b/examples/plot_tokamak_neutron_source_strengths.py
@@ -27,7 +27,7 @@ temperatures = tokamak_ion_temperature(
     ion_temperature_beta=2,
     ion_temperature_peaking_factor=8.06,
     ion_temperature_separatrix=0.1,
-    major_radius=major_radius,
+    minor_radius=minor_radius,
 )
 
 densities = tokamak_ion_density(
@@ -35,7 +35,7 @@ densities = tokamak_ion_density(
     ion_density_centre=ion_density_centre,
     ion_density_peaking_factor=1,
     ion_density_pedestal=1.09e20,
-    major_radius=major_radius,
+    minor_radius=minor_radius,
     pedestal_radius=0.8 * minor_radius,
     ion_density_separatrix=3e19,
     r=a,

--- a/src/openmc_plasma_source/tokamak_source.py
+++ b/src/openmc_plasma_source/tokamak_source.py
@@ -122,7 +122,7 @@ def tokamak_source(
     """
     # create a sample of (a, alpha) coordinates
     rng = np.random.default_rng(sample_seed)
-    a = rng.random(sample_size) * minor_radius
+    a = rng.random(sample_size) * minor_radius   # a is local minor radius
     alpha = rng.random(sample_size) * 2 * np.pi
 
     # compute densities, temperatures
@@ -131,7 +131,7 @@ def tokamak_source(
         ion_density_centre=ion_density_centre,
         ion_density_peaking_factor=ion_density_peaking_factor,
         ion_density_pedestal=ion_density_pedestal,
-        major_radius=major_radius,
+        minor_radius=minor_radius,
         pedestal_radius=pedestal_radius,
         ion_density_separatrix=ion_density_separatrix,
         r=a,
@@ -147,7 +147,7 @@ def tokamak_source(
         ion_temperature_beta=ion_temperature_beta,
         ion_temperature_peaking_factor=ion_temperature_peaking_factor,
         ion_temperature_separatrix=ion_temperature_separatrix / 1e3,
-        major_radius=major_radius,
+        minor_radius=minor_radius,
     )
 
     # convert coordinates
@@ -206,7 +206,7 @@ def tokamak_ion_density(
     ion_density_centre: float,
     ion_density_peaking_factor: float,
     ion_density_pedestal: float,
-    major_radius: float,
+    minor_radius: float,
     pedestal_radius: float,
     ion_density_separatrix: float,
     r: Union[float, NDArray],
@@ -221,10 +221,10 @@ def tokamak_ion_density(
         ion_density_peaking_factor: Ion density peaking factor
             (referred in [1] as ion density exponent)
         ion_density_pedestal: Ion density at pedestal (m-3)
-        major_radius: Plasma major radius (cm)
+        minor_radius: Plasma minor radius (cm)
         pedestal_radius: Minor radius at pedestal (cm)
         ion_density_separatrix: Ion density at separatrix (m-3)
-        r: Minor radius (cm)
+        r: Local minor radius (cm)
 
     Returns:
         ion density in m-3
@@ -237,7 +237,7 @@ def tokamak_ion_density(
     if mode == "L":
         density = (
             ion_density_centre
-            * (1 - (r / major_radius) ** 2) ** ion_density_peaking_factor
+            * (1 - (r / minor_radius) ** 2) ** ion_density_peaking_factor
         )
     elif mode in ["H", "A"]:
         density = np.where(
@@ -249,8 +249,8 @@ def tokamak_ion_density(
             ),
             (
                 (ion_density_pedestal - ion_density_separatrix)
-                * (major_radius - r)
-                / (major_radius - pedestal_radius)
+                * (minor_radius - r)
+                / (minor_radius - pedestal_radius)
                 + ion_density_separatrix
             ),
         )
@@ -266,14 +266,14 @@ def tokamak_ion_temperature(
     ion_temperature_beta: float,
     ion_temperature_peaking_factor: float,
     ion_temperature_separatrix: float,
-    major_radius: float,
+    minor_radius: float,
 ) -> NDArray:
     """
     Computes the ion temperature at a given position. The ion
     temperature is only dependent on the minor radius.
 
     Args:
-        r: Minor radius (cm)
+        r: Local minor radius (cm)
         mode: Confinement mode ("L", "H", "A")
         pedestal_radius: Minor radius at pedestal (cm)
         ion_temperature_pedestal: Ion temperature at pedestal (eV)
@@ -283,7 +283,7 @@ def tokamak_ion_temperature(
         ion_temperature_peaking_factor: Ion temperature peaking
             factor
         ion_temperature_separatrix: Ion temperature at separatrix (eV)
-        major_radius: Plasma major radius (cm)
+        minor_radius: Plasma minor radius (cm)
 
 
     Returns:
@@ -297,7 +297,7 @@ def tokamak_ion_temperature(
     if mode == "L":
         temperature = (
             ion_temperature_centre
-            * (1 - (r / major_radius) ** 2) ** ion_temperature_peaking_factor
+            * (1 - (r / minor_radius) ** 2) ** ion_temperature_peaking_factor
         )
     elif mode in ["H", "A"]:
         temperature = np.where(
@@ -311,8 +311,8 @@ def tokamak_ion_temperature(
             (
                 ion_temperature_separatrix
                 + (ion_temperature_pedestal - ion_temperature_separatrix)
-                * (major_radius - r)
-                / (major_radius - pedestal_radius)
+                * (minor_radius - r)
+                / (minor_radius - pedestal_radius)
             ),
         )
     return temperature * 1e3

--- a/tests/test_tokamak_source.py
+++ b/tests/test_tokamak_source.py
@@ -198,7 +198,7 @@ def test_ion_density(tokamak_args_dict):
         ion_density_centre=tokamak_args_dict["ion_density_centre"],
         ion_density_peaking_factor=tokamak_args_dict["ion_density_peaking_factor"],
         ion_density_pedestal=tokamak_args_dict["ion_density_pedestal"],
-        major_radius=tokamak_args_dict["major_radius"],
+        minor_radius=tokamak_args_dict["minor_radius"],
         pedestal_radius=tokamak_args_dict["pedestal_radius"],
         ion_density_separatrix=tokamak_args_dict["ion_density_separatrix"],
     )
@@ -217,7 +217,7 @@ def test_bad_ion_density(tokamak_args_dict):
             ion_density_centre=tokamak_args_dict["ion_density_centre"],
             ion_density_peaking_factor=tokamak_args_dict["ion_density_peaking_factor"],
             ion_density_pedestal=tokamak_args_dict["ion_density_pedestal"],
-            major_radius=tokamak_args_dict["major_radius"],
+            minor_radius=tokamak_args_dict["minor_radius"],
             pedestal_radius=tokamak_args_dict["pedestal_radius"],
             ion_density_separatrix=tokamak_args_dict["ion_density_separatrix"],
         )
@@ -238,7 +238,7 @@ def test_ion_temperature(tokamak_args_dict, tokamak_source_example):
             "ion_temperature_peaking_factor"
         ],
         ion_temperature_separatrix=tokamak_args_dict["ion_temperature_separatrix"],
-        major_radius=tokamak_args_dict["major_radius"],
+        minor_radius=tokamak_args_dict["minor_radius"],
     )
     assert isinstance(temperature, np.ndarray)
     assert len(temperature) == len(r)
@@ -260,7 +260,7 @@ def test_bad_ion_temperature(tokamak_args_dict):
                 "ion_temperature_peaking_factor"
             ],
             ion_temperature_separatrix=tokamak_args_dict["ion_temperature_separatrix"],
-            major_radius=tokamak_args_dict["major_radius"],
+            minor_radius=tokamak_args_dict["minor_radius"],
         )
     assert "must not be negative" in str(excinfo.value)
 


### PR DESCRIPTION
The following screenshots have been taken from the [paper](https://www.researchgate.net/publication/257318050_Tokamak_D-T_neutron_source_models_for_different_plasma_physics_confinement_modes) which has been used to define the tokamak plasma source in this open source repository.

<img width="479" height="822" alt="Screenshot From 2026-05-29 00-01-08" src="https://github.com/user-attachments/assets/d8580498-45c0-4110-a14b-de58535c819a" />

---
As it can be seen from the highlighted lines and from the **Fig. 1** that **'A'** is the **minor radius** of plasma. And **'a'** is the local minor radius of plasma.

**L-mode ion density and ion temperature is given by**
<img width="450" height="156" alt="Screenshot From 2026-05-29 00-05-56" src="https://github.com/user-attachments/assets/c722c310-4f2e-4fa7-a617-1f70dbc2733f" />


**H and A-modes ion density and ion temperature is given by**
<img width="462" height="332" alt="Screenshot From 2026-05-29 00-08-36" src="https://github.com/user-attachments/assets/41a6e8e4-dbfb-4123-bd85-6dcb146ff5d5" />

So, to calculate ion density and ion temperature, we need the **ratio of local plasma minor radius(a)** to **plasma minor radius(A)**.

But in the **tokamak_ion_temperature()** and **tokamak_ion_density()** methods, it has defined as the **ratio of local minor radius(a)** to **plasma major radius(R0)**,  which doesn't correctly follow the physics.

So the main problem was between the major and minor radius  misplacement in those methods.

**Fixes issue #114** 