### PR TITLE
Weight tokamak source strengths by plasma volume element (R * |J|)

### DIFF
--- a/src/openmc_plasma_source/tokamak_source.py
+++ b/src/openmc_plasma_source/tokamak_source.py
@@ -161,6 +161,20 @@ def tokamak_source(
         elongation=elongation,
     )
 
+    # Weight each sample by the plasma volume element it represents. Samples are
+    # drawn uniformly in (a, alpha), so to recover the true spatial neutron
+    # emission each sample must be weighted by the local volume per unit
+    # (a, alpha): dV is proportional to R * |d(R,Z)/d(a,alpha)|, i.e. the
+    # toroidal factor R times the poloidal cross-sectional Jacobian |J|.
+    # Without this weighting the core (small a, small R) is over-represented.
+    theta = alpha + triangularity * np.sin(alpha)
+    dR_da = np.cos(theta) - 2 * shafranov_factor * a / minor_radius**2
+    dR_dalpha = -a * np.sin(theta) * (1 + triangularity * np.cos(alpha))
+    dZ_da = elongation * np.sin(alpha)
+    dZ_dalpha = elongation * a * np.cos(alpha)
+    jacobian = np.abs(dR_da * dZ_dalpha - dR_dalpha * dZ_da)
+    volume_weight = RZ[0] * jacobian
+
     fuel_densities = {}
     for key, value in fuel.items():
         fuel_densities[key] = densities * value
@@ -183,6 +197,11 @@ def tokamak_source(
         if reaction == "TT":
             # TT reaction emits 2 neutrons
             neutron_source_density[reaction] = neutron_source_density[reaction] * 2
+
+        # apply the (a, alpha) volume element weighting (toroidal R * Jacobian)
+        neutron_source_density[reaction] = (
+            neutron_source_density[reaction] * volume_weight
+        )
 
         total_source_density += np.sum(neutron_source_density[reaction])
 

--- a/tests/test_tokamak_source.py
+++ b/tests/test_tokamak_source.py
@@ -429,3 +429,26 @@ def test_source_locations_are_within_correct_range(tokamak_source):
         assert approx_gt(R_min, R_0 - A)
         assert approx_lt(R, R_max)
         assert approx_gt(R, R_min)
+
+
+def test_strengths_are_volume_weighted(tokamak_args_dict):
+    """Source strengths must include the plasma volume element.
+
+    Samples are drawn uniformly in (a, alpha), so the neutron source density
+    must be weighted by the local volume per unit (a, alpha), which is
+    proportional to the toroidal factor R times the poloidal cross-sectional
+    Jacobian |d(R,Z)/d(a,alpha)|. Applying this weighting biases the emission
+    outward in R relative to the raw (unweighted) sample distribution. See
+    "Tokamak D-T neutron source models for different plasma physics confinement
+    modes", C. Fausser et al., Fusion Engineering and Design, 2012.
+    """
+    sources = tokamak_source(**tokamak_args_dict)
+    strengths = np.array([source.strength for source in sources])
+    R = np.array([source.space.r.x[0] for source in sources])
+
+    # strengths remain normalised after volume weighting
+    assert pytest.approx(strengths.sum()) == 1
+
+    # the R * |J| volume weighting shifts the strength-weighted mean major
+    # radius outward relative to the unweighted (uniform a, alpha) sample mean
+    assert np.average(R, weights=strengths) > R.mean()


### PR DESCRIPTION
## Problem

In `tokamak_source`, plasma samples are drawn uniformly in `(a, alpha)` coordinates, and each sample becomes a ring source whose `strength` was set to `neutron_source_density / total` — the per-unit-volume emission only.

This ignores the plasma **volume element** that each `(a, alpha)` sample represents. In a tokamak the real-space volume per unit `(a, alpha)` is proportional to:

- the **toroidal factor `R`** (the circumference of the ring ∝ 2πR), and
- the **poloidal cross-sectional Jacobian** `|J| = |∂(R,Z)/∂(a,alpha)|`.

Without these factors the core of the plasma (small `a`, small `R`) is over-represented in the emitted source, so the neutron source distribution does not match the physical emission.

## Fix

Weight each sample's source density by `volume_weight = R * |J|` before normalising the strengths:

- `|J|` is computed analytically from the `(a, alpha) -> (R, Z)` mapping, including triangularity, elongation and the Shafranov-shift derivative.
- `R` is the major-radius coordinate of each sample.

Strengths are still normalised to sum to 1, so existing behaviour (normalisation) is preserved while the radial distribution is corrected.

## Verification

- `test_strengths_are_normalised`, `test_creation`, `test_source_locations_are_within_correct_range` still pass (source locations are unchanged; only strengths change).
- Added `test_strengths_are_volume_weighted`, asserting the strength-weighted mean major radius is biased outward relative to the unweighted sample mean.
- Sanity check on realistic parameters: strength-weighted mean R shifts outward (e.g. 9.17 m -> 9.41 m for the test fixture), as expected.

Reference: C. Fausser et al., "Tokamak D-T neutron source models for different plasma physics confinement modes", Fusion Engineering and Design, 2012.