### PR TITLE
fix DD and TT ion_density formula

### DIFF
--- a/src/openmc_plasma_source/tokamak_source.py
+++ b/src/openmc_plasma_source/tokamak_source.py
@@ -209,9 +209,9 @@ def tokamak_source(
     total_source_density = np.zeros_like(a_flat)
     for reaction in reactions:
         if reaction == "DD":
-            fuel_density = fuel_densities["D"] * 0.5
+            fuel_density =  0.5 * fuel_densities["D"]**2
         elif reaction == "TT":
-            fuel_density = fuel_densities["T"] * 0.5
+            fuel_density = 0.5 * fuel_densities["T"]**2
         elif reaction == "DT":
             fuel_density = fuel_densities["T"] * fuel_densities["D"]
 


### PR DESCRIPTION
As mentioned in `Fausser et al., Tokamak D-T neutron source models for different plasma physics confinement modes, Fusion Engineering and Design (2012). https://doi.org/10.1016/j.fusengdes.2012.02.025`

<img width="465" height="110" alt="Screenshot From 2026-05-29 22-06-30" src="https://github.com/user-attachments/assets/5b312b59-12f3-4254-bdbc-e776e9e7ad1c" />

---

Also from `Bielecki, J., Kurowski, A. Neutron Diagnostics for Tokamak Plasma: From a Plasma Diagnostician Perspective. J Fusion Energ 38, 386–393 (2019). https://doi.org/10.1007/s10894-018-0195-9`

<img width="837" height="388" alt="Screenshot From 2026-05-29 22-11-37" src="https://github.com/user-attachments/assets/2db367c7-3d8f-42cb-a098-21076d1bc988" />

---

We can confirm that we need to square the ion density for two identical fuel reactions.