### PR TITLE
remove safety factor from R_min and R-max

### DIFF
--- a/src/openmc_plasma_source/tokamak_source.py
+++ b/src/openmc_plasma_source/tokamak_source.py
@@ -129,8 +129,8 @@ def tokamak_source(
     n_r, n_phi, n_z = mesh_resolution
 
     # Compute mesh bounds from geometry
-    R_min = major_radius - minor_radius - abs(shafranov_factor)
-    R_max = major_radius + minor_radius + abs(shafranov_factor)
+    R_min = major_radius - minor_radius
+    R_max = major_radius + minor_radius
     Z_max = elongation * minor_radius
 
     # Create cylindrical mesh


### PR DESCRIPTION
As we can see from `Fausser et al., Tokamak D-T neutron source models for different plasma physics confinement modes, Fusion Engineering and Design (2012). https://doi.org/10.1016/j.fusengdes.2012.02.025`
<img width="466" height="156" alt="Screenshot From 2026-05-29 23-41-14" src="https://github.com/user-attachments/assets/77ae34f3-b581-4284-b43f-944f60e5e4b0" />

So, when` a = 0`, we get `R = R0 + esh` and when `a = A`, we get `R = R0 + A`. So, the 2nd and 3rd term never peak together in e`quation 2`. And we have converted our R and Z using those above formula in the code. So, I guess we do not need the safety factor for R_max and R_min. Though it will not affect much but i guess as there is no chance of exceeding the boundary, we don't need it.