### PR TITLE
Expose only (R, Z) mesh resolution in tokamak_source

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ my_source = tokamak_source(
     # ... plasma parameters as above ...
     start_angle=0,                 # toroidal start angle in radians
     rotation_angle=2 * 3.14159,    # toroidal extent in radians
-    mesh_resolution=(100, 1, 100), # number of mesh bins in (r, phi, z)
+    mesh_resolution=(100, 100), # number of mesh bins in (r, z)
     grid_density=500,              # points per dimension in the (a, alpha) grid
 )
 ```

--- a/examples/plot_mesh_source.py
+++ b/examples/plot_mesh_source.py
@@ -22,7 +22,7 @@ mesh_source = tokamak_source(
     shafranov_factor=0.44789,
     triangularity=0.270,
     fuel={"D": 0.5, "T": 0.5},
-    mesh_resolution=(100, 1, 100),
+    mesh_resolution=(100, 100),
     grid_density=500,
 )
 

--- a/examples/tokamak_source_plot.py
+++ b/examples/tokamak_source_plot.py
@@ -67,7 +67,7 @@ def sample_points(start_angle, rotation_angle):
         **PLASMA,
         start_angle=0.0,
         rotation_angle=2 * np.pi,
-        mesh_resolution=(100, 1, 100),
+        mesh_resolution=(100, 100),
     )
     n_r = len(source.mesh.r_grid) - 1
     n_z = len(source.mesh.z_grid) - 1

--- a/src/openmc_plasma_source/tokamak_source.py
+++ b/src/openmc_plasma_source/tokamak_source.py
@@ -86,7 +86,7 @@ def tokamak_source(
     shafranov_factor: float,
     start_angle: float = 0.0,
     rotation_angle: float = 2 * np.pi,
-    mesh_resolution: Tuple[int, int, int] = (100, 1, 100),
+    mesh_resolution: Tuple[int, int] = (100, 100),
     grid_density: int = 500,
     fuel: Dict[str, float] = {"D": 0.5, "T": 0.5},
 ) -> openmc.MeshSource:
@@ -141,8 +141,11 @@ def tokamak_source(
             extends the plasma in the opposite direction from start_angle. A
             sector that crosses the 0 / 2*pi seam is supported via a full-circle
             mesh with a zero-strength bin filling the unselected portion.
-        mesh_resolution: Number of mesh bins in (r, phi, z).
-            Defaults to (100, 1, 100).
+        mesh_resolution: Number of mesh bins in (r, z) as a tuple of two
+            values. Defaults to (100, 100). The toroidal (phi) dimension is
+            not exposed: the source is axisymmetric (density and temperature
+            depend only on the minor radius) so the toroidal direction carries
+            no structure and is handled internally.
         grid_density: Number of points per dimension in the internal
             (a, alpha) grid used for forward mapping. Defaults to 500.
         fuel: Isotopes as keys and atom fractions as values
@@ -192,7 +195,17 @@ def tokamak_source(
             "rotation_angle must be a non-zero float between -2*pi and 2*pi"
         )
 
-    n_r, n_phi, n_z = mesh_resolution
+    if len(mesh_resolution) != 2:
+        raise ValueError(
+            "mesh_resolution must be a tuple of two values (n_r, n_z). The "
+            "toroidal dimension is axisymmetric and is handled internally, so "
+            "it is no longer a user parameter."
+        )
+    n_r, n_z = mesh_resolution
+    # The source is axisymmetric, so a single toroidal bin spanning the sector
+    # is sufficient. _toroidal_phi_grid still expands this internally to add a
+    # zero-strength dead bin when the sector crosses the 0 / 2*pi seam.
+    n_phi = 1
 
     # Compute mesh bounds from geometry
     R_min = major_radius - minor_radius - abs(shafranov_factor)

--- a/tests/test_tokamak_source.py
+++ b/tests/test_tokamak_source.py
@@ -13,7 +13,7 @@ from openmc_plasma_source import (
 from openmc_plasma_source.tokamak_source import _toroidal_phi_grid
 
 # Small mesh/grid params used across tests for speed
-FAST_MESH = (20, 1, 20)
+FAST_MESH = (20, 20)
 FAST_GRID = 50
 
 
@@ -247,6 +247,28 @@ def test_bad_rotation_angle(tokamak_args_dict, rotation_angle):
         tokamak_source(**tokamak_args_dict)
 
 
+@pytest.mark.parametrize("mesh_resolution", [(10, 1, 10), (10,), (10, 10, 10, 10)])
+def test_bad_mesh_resolution(tokamak_args_dict, mesh_resolution):
+    """mesh_resolution must be a 2-tuple (n_r, n_z); other lengths are rejected.
+
+    In particular the old 3-tuple (n_r, n_phi, n_z) form should fail with a
+    helpful message rather than silently mis-binning.
+    """
+    tokamak_args_dict["mesh_resolution"] = mesh_resolution
+    with pytest.raises(ValueError, match="two values"):
+        tokamak_source(**tokamak_args_dict)
+
+
+def test_mesh_resolution_sets_single_phi_bin(tokamak_args_dict):
+    """A 2-tuple (n_r, n_z) yields a mesh whose toroidal dimension is a single
+    bin for a full rotation, and the requested r/z resolution."""
+    tokamak_args_dict["mesh_resolution"] = (12, 8)
+    tokamak_args_dict["rotation_angle"] = 2 * np.pi
+    source = tokamak_source(**tokamak_args_dict)
+    n_r, n_phi, n_z = source.mesh.dimension
+    assert (n_r, n_phi, n_z) == (12, 1, 8)
+
+
 def test_ion_density(tokamak_args_dict):
     # test with values of r that are within acceptable ranges.
     r = np.linspace(0.0, tokamak_args_dict["minor_radius"], 100)
@@ -427,7 +449,7 @@ def tokamak_source_strategy(draw):
         ion_temperature_separatrix=0.1,
         mode="H",
         ion_temperature_beta=6,
-        mesh_resolution=(10, 1, 10),
+        mesh_resolution=(10, 10),
         grid_density=30,
     ), {
         "major_radius": major_radius,


### PR DESCRIPTION
Closes #127.

## What

`tokamak_source` previously took `mesh_resolution` as a 3-tuple `(n_r, n_phi, n_z)`, defaulting to `(100, 1, 100)`. The toroidal (phi) value was almost always `1` and added no fidelity, because the source is **axisymmetric**: `tokamak_ion_density` and `tokamak_ion_temperature` depend only on the minor radius, so there is no structure in the toroidal direction. Increasing `n_phi` just sliced the sector into equal-strength duplicate bins.

This PR makes `mesh_resolution` a 2-tuple `(n_r, n_z)`, defaulting to `(100, 100)`, and handles the toroidal binning internally.

## Changes

- `tokamak_source` signature: `mesh_resolution: Tuple[int, int] = (100, 100)`.
- Internally set `n_phi = 1`. `_toroidal_phi_grid` is unchanged and still expands this to add the zero-strength "dead" bin when a sector crosses the 0 / 2*pi seam, so seam-crossing behaviour is preserved.
- Passing the old 3-tuple (or any non-2 length) now raises a clear `ValueError` guiding migration, rather than silently mis-binning.
- Updated docstring, `README.md`, and the `examples/` to the 2-tuple form.

## Tests

- Added `test_bad_mesh_resolution` (rejects `(10, 1, 10)`, `(10,)`, `(10, 10, 10, 10)` with a helpful message).
- Added `test_mesh_resolution_sets_single_phi_bin` (a `(12, 8)` request yields mesh dimension `(12, 1, 8)`).
- Full suite passes (154 tests).

## Note

This is a **breaking signature change**: callers passing `(n_r, n_phi, n_z)` must drop the middle value. The new `ValueError` makes the required change obvious.
