### PR TITLE
Fix sample() unpacking error in ring_source_angles_plot.py

### DIFF
--- a/examples/ring_source_angles_plot.py
+++ b/examples/ring_source_angles_plot.py
@@ -59,9 +59,9 @@ for i, case in enumerate(cases):
     )[0]
 
     space = source.space
-    r, _ = space.r.sample(N_SAMPLES, seed=i + 1)
-    phi, _ = space.phi.sample(N_SAMPLES, seed=i + 1)
-    z, _ = space.z.sample(N_SAMPLES, seed=i + 1)
+    r = space.r.sample(N_SAMPLES, seed=i + 1)
+    phi = space.phi.sample(N_SAMPLES, seed=i + 1)
+    z = space.z.sample(N_SAMPLES, seed=i + 1)
 
     x = r * np.cos(phi)
     y = r * np.sin(phi)


### PR DESCRIPTION
This PR fixes the CI test error occured in #130 

The [documentation](https://docs.openmc.org/en/stable/_modules/openmc/stats/univariate.html) confirms that `sample()` method returns a 1-D array of sampled values. But the current implementation `r, _ = space.r.sample(N_SAMPLES, seed=i + 1)` is trying to unpack a flat array of 2000 floats, not a 2-element tuple.

So, removing the `_,`  destructuring on all three `.sample()` calls.